### PR TITLE
project_onto_line

### DIFF
--- a/Core/Point.hpp
+++ b/Core/Point.hpp
@@ -144,6 +144,23 @@ public:
     return result;
   }
 
+//Added
+  Point<T, Dim> project_onto_line(const Point<T, Dim>& line_point1, const Point<T, Dim>& line_point2) const {
+    Point<T, Dim> AB = line_point2 - line_point1;
+    Point<T, Dim> AP = *this - line_point1;
+
+    T dot_AP_AB = AP.dot(AB);
+    T dot_AB_AB = AB.dot(AB);
+
+    if (dot_AB_AB == 0) {
+        throw std::runtime_error("Line points must be distinct");
+    }
+
+    T factor = dot_AP_AB / dot_AB_AB;
+    return line_point1 + AB * factor;
+  }
+
+
   void print() const {
     std::cout << "(";
     for (size_t i = 0; i < Dim; ++i) {

--- a/tests/test_point.cpp
+++ b/tests/test_point.cpp
@@ -204,3 +204,48 @@ TEST(TestReflection, TestReflection3D) {
   EXPECT_DOUBLE_EQ(result[1], Expected[1]);
   EXPECT_DOUBLE_EQ(result[2], Expected[2]);
 }
+
+TEST(PointTest, ProjectionOntoLine2D) {
+  std::array<double, 2> p_coords = {3.0, 4.0};
+  std::array<double, 2> line_p1_coords = {1.0, 1.0};
+  std::array<double, 2> line_p2_coords = {5.0, 5.0};
+
+  Point2D p(p_coords);
+  Point2D line_p1(line_p1_coords);
+  Point2D line_p2(line_p2_coords);
+
+  Point2D projected = p.project_onto_line(line_p1, line_p2);
+
+  std::array<double, 2> expected_coords = {3.5, 3.5}; // Expected projection
+  EXPECT_NEAR(projected[0], expected_coords[0], 1e-9);
+  EXPECT_NEAR(projected[1], expected_coords[1], 1e-9);
+}
+
+TEST(PointTest, ProjectionOntoLine3D) {
+  std::array<double, 3> p_coords = {2.0, 3.0, 4.0};
+  std::array<double, 3> line_p1_coords = {0.0, 0.0, 0.0};
+  std::array<double, 3> line_p2_coords = {1.0, 1.0, 1.0};
+
+  Point3D p(p_coords);
+  Point3D line_p1(line_p1_coords);
+  Point3D line_p2(line_p2_coords);
+
+  Point3D projected = p.project_onto_line(line_p1, line_p2);
+
+  std::array<double, 3> expected_coords = {3.0, 3.0, 3.0}; // Expected projection
+  EXPECT_NEAR(projected[0], expected_coords[0], 1e-9);
+  EXPECT_NEAR(projected[1], expected_coords[1], 1e-9);
+  EXPECT_NEAR(projected[2], expected_coords[2], 1e-9);
+}
+
+TEST(PointTest, ProjectionOntoDegenerateLine) {
+  std::array<double, 2> p_coords = {3.0, 4.0};
+  std::array<double, 2> line_p1_coords = {2.0, 2.0};
+  std::array<double, 2> line_p2_coords = {2.0, 2.0}; // Degenerate case (same points)
+
+  Point2D p(p_coords);
+  Point2D line_p1(line_p1_coords);
+  Point2D line_p2(line_p2_coords);
+
+  EXPECT_THROW(p.project_onto_line(line_p1, line_p2), std::runtime_error);
+}


### PR DESCRIPTION
Implemented project_onto_line() to project a point onto a line defined by two points.
Supports any dimension.
Ensures proper error handling for invalid cases.
Fixes: #14  🚀

Pls review the commit