### PR TITLE
Added lerp() function to the Point class for linear interpolation

### DIFF
--- a/Core/Point.hpp
+++ b/Core/Point.hpp
@@ -182,7 +182,12 @@ public:
     auto determinant =
         (p2[0] - p1[0]) * (p3[1] - p1[1]) - (p2[1] - p1[1]) * (p3[0] - p1[0]);
     return std::abs(determinant) < 1e-9;
-  }
-};
 
-} // namespace GeomCPP
+    static Point<T, Dim> lerp(const Point<T, Dim>& p1, const Point<T, Dim>& p2, T t) {
+      Point<T, Dim> result;
+      for (std::size_t i = 0; i < Dim; ++i) {
+          result[i] = p1[i] + t * (p2[i] - p1[i]);
+      }
+      return result;
+  }
+}; // namespace GeomCPP

--- a/tests/test_point.cpp
+++ b/tests/test_point.cpp
@@ -288,3 +288,13 @@ TEST(PointTest, ProjectionOntoDegenerateLine) {
 
   EXPECT_THROW(p.project_onto_line(line_p1, line_p2), std::runtime_error);
 }
+
+TEST(PointTest, LerpFunction) {
+  GeomCPP::Point<double, 2> p1 = {{0.0, 0.0}};
+  GeomCPP::Point<double, 2> p2 = {{10.0, 10.0}};
+
+  GeomCPP::Point<double, 2> midPoint = GeomCPP::Point<double, 2>::lerp(p1, p2, 0.5);
+
+  EXPECT_DOUBLE_EQ(midPoint[0], 5.0);
+  EXPECT_DOUBLE_EQ(midPoint[1], 5.0);
+}


### PR DESCRIPTION
Changes Introduced:
* Implemented a static lerp() function in Point.hpp to perform linear interpolation between two points.
* Supports points of arbitrary dimensions.
* Uses the formula:
result[i]=p1[i]+t×(p2[i]−p1[i])
* Added test cases to validate the implementation.